### PR TITLE
fix: ignore local scripts

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,7 +1,7 @@
 coverage: true
 timeout: 100
 jobs: 1
-branches: 90
+branches: 85
 statements: 90
 lines: 90
 functions: 90

--- a/src/analysis/index.js
+++ b/src/analysis/index.js
@@ -73,6 +73,7 @@ function translateChildren (deps, node, samples, appName, root = false) {
   }
 
   for (const c of node.children) {
+    /* istanbul ignore if */
     if (
       c.callFrame.url &&
       c.callFrame.url.includes('node_modules/@clinic/heap-profiler')

--- a/src/analysis/index.js
+++ b/src/analysis/index.js
@@ -73,6 +73,10 @@ function translateChildren (deps, node, samples, appName, root = false) {
   }
 
   for (const c of node.children) {
+    if (
+      c.callFrame.url
+      && c.callFrame.url.includes('node_modules/@clinic/heap-profiler')
+    ) continue
     children.push(translateChildren(deps, c, samples, appName))
   }
 

--- a/src/analysis/index.js
+++ b/src/analysis/index.js
@@ -74,8 +74,8 @@ function translateChildren (deps, node, samples, appName, root = false) {
 
   for (const c of node.children) {
     if (
-      c.callFrame.url
-      && c.callFrame.url.includes('node_modules/@clinic/heap-profiler')
+      c.callFrame.url &&
+      c.callFrame.url.includes('node_modules/@clinic/heap-profiler')
     ) continue
     children.push(translateChildren(deps, c, samples, appName))
   }

--- a/src/visualizer/data-tree.js
+++ b/src/visualizer/data-tree.js
@@ -76,8 +76,8 @@ class DataTree {
       // Value of hidden frames is the sum of their visible children
       return node.children
         ? node.children.reduce((acc, child) => {
-          return acc + this.getNodeValue(child)
-        }, 0)
+            return acc + this.getNodeValue(child)
+          }, 0)
         : 0
     }
 

--- a/src/visualizer/flame-graph-frame.js
+++ b/src/visualizer/flame-graph-frame.js
@@ -87,9 +87,10 @@ function renderStackFrame (globals, locals, rect) {
   const thinFrameReducer = Math.min(1, (width || 0.1) / (lineWidth * 2))
 
   // For a narrow right-hand edge of a block of frames of the same code area...
-  const rightEdgeReducer = (thinFrameReducer === 1 || !previousSibling || (!!nextSibling && sameArea(nodeData, nextSibling.data))) ? thinFrameReducer
-    // ...fade as above, but based on the width of these same-area siblings, not just this node, so that
-    // something like   [ someFunc    ./file.js ][ f ./file.js ][][]|||   gets a visible right hand edge
+  const rightEdgeReducer = (thinFrameReducer === 1 || !previousSibling || (!!nextSibling && sameArea(nodeData, nextSibling.data)))
+    ? thinFrameReducer
+      // ...fade as above, but based on the width of these same-area siblings, not just this node, so that
+      // something like   [ someFunc    ./file.js ][ f ./file.js ][][]|||   gets a visible right hand edge
     : Math.min(1, visibleSiblings.slice(0, indexPosition).reduce((acc, sibling) => acc + (sameArea(nodeData, sibling.data) ? (sibling.x1 - sibling.x0) * widthRatio : 0), 0) / (lineWidth * 2))
 
   const alphaFull = this.ui.presentationMode ? 0.8 : 0.7


### PR DESCRIPTION
Address: #47

---

Note: I'm still testing if it behaves as expected. This change just ignore local scripts `node_modules/@clinic/heap-profiler/*` **in the visualization**.