### PR TITLE
doc: add issue repository location

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Programmable interface to [Clinic.js][clinic-url] Heap Profiler. Learn more abou
 
 ## Issues
 
-To open an issue, please use the [main repository](https://github.com/clinicjs/node-clinic) with the `bubbleprof` label.
+To open an issue, please use the [main repository](https://github.com/clinicjs/node-clinic) with the `heapprofiler` label.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Programmable interface to [Clinic.js][clinic-url] Heap Profiler. Learn more abou
 
 ![screenshot](https://user-images.githubusercontent.com/26234614/143886238-481abe39-4cc7-470a-a1cd-144a73a070b9.png)
 
+## Issues
+
+To open an issue, please use the [main repository](https://github.com/clinicjs/node-clinic) with the `bubbleprof` label.
+
 ## Installation
 
 ```console


### PR DESCRIPTION
To improve the maintainability of this project. I've removed the "issues" tab and transferred all the open issues to node-clinic with `heapprofiler` label.